### PR TITLE
Refactor filter system

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/event/match/MatchModuleLoadCompleteEvent.java
+++ b/src/main/java/in/twizmwaz/cardinal/event/match/MatchModuleLoadCompleteEvent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.event.match;
+
+import in.twizmwaz.cardinal.event.MatchEvent;
+import in.twizmwaz.cardinal.match.Match;
+import lombok.Getter;
+import org.bukkit.event.HandlerList;
+
+public class MatchModuleLoadCompleteEvent extends MatchEvent {
+
+  @Getter
+  private static final HandlerList handlerList = new HandlerList();
+
+  public MatchModuleLoadCompleteEvent(Match match) {
+    super(match);
+  }
+
+  @Override
+  public HandlerList getHandlers() {
+    return handlerList;
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/ModuleHandler.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/ModuleHandler.java
@@ -26,11 +26,13 @@
 package in.twizmwaz.cardinal.module;
 
 import in.twizmwaz.cardinal.Cardinal;
+import in.twizmwaz.cardinal.event.match.MatchModuleLoadCompleteEvent;
 import in.twizmwaz.cardinal.match.Match;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang.Validate;
+import org.bukkit.Bukkit;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -67,8 +69,10 @@ public class ModuleHandler {
         }
       } catch (Throwable throwable) {
         throwable.printStackTrace();
-        continue;
       }
+    }
+    Bukkit.getPluginManager().callEvent(new MatchModuleLoadCompleteEvent(match));
+    for (Module module : registry.getLoadOrder()) {
       sendErrorMessages(match, module);
     }
     Cardinal.getInstance().getLogger().info("Modules for " + match.getMap().getName() + " loaded successfully.");

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/Filter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/Filter.java
@@ -25,8 +25,8 @@
 
 package in.twizmwaz.cardinal.module.filter;
 
-public interface Filter<T> {
+public interface Filter {
 
-  boolean evaluate(T evaluating);
+  FilterState evaluate(Object... evaluating);
 
 }

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/FilterState.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/FilterState.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter;
+
+public enum FilterState {
+
+  ALLOW,
+  DENY,
+  ABSTAIN;
+
+  public static FilterState fromBoolean(Boolean state) {
+    return state == null ? ABSTAIN : state ? ALLOW : DENY;
+  }
+
+  public boolean toBoolean() {
+    return !this.equals(DENY);
+  }
+
+  public boolean hasResult() {
+    return !this.equals(ABSTAIN);
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/LoadLateFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/LoadLateFilter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter;
+
+import in.twizmwaz.cardinal.match.Match;
+
+// Fixme: lacks a better name
+public interface LoadLateFilter {
+
+  void load(Match match) throws FilterException;
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/exception/property/MissingFilterChildException.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/exception/property/MissingFilterChildException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.exception.property;
+
+import in.twizmwaz.cardinal.module.filter.exception.FilterPropertyException;
+import org.jdom2.Element;
+
+public class MissingFilterChildException extends FilterPropertyException {
+
+  public MissingFilterChildException(String child, Element element) {
+    super(child, element);
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/parser/CauseFilterParser.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/parser/CauseFilterParser.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.parser;
+
+import in.twizmwaz.cardinal.module.filter.FilterException;
+import in.twizmwaz.cardinal.module.filter.FilterParser;
+import in.twizmwaz.cardinal.module.filter.exception.property.InvalidFilterPropertyException;
+import in.twizmwaz.cardinal.module.filter.exception.property.MissingFilterPropertyException;
+import in.twizmwaz.cardinal.module.filter.type.CauseFilter;
+import lombok.Getter;
+import org.jdom2.Element;
+
+@Getter
+public class CauseFilterParser implements FilterParser {
+
+  private final CauseFilter.EventCause cause;
+
+  /**
+   * Parses an element for a cause filter.
+   *
+   * @param element The element.
+   * @throws FilterException Thrown if the cause property is missing or invalid.
+   */
+  public CauseFilterParser(Element element) throws FilterException {
+    String causeProperty = element.getText();
+    if (causeProperty == null) {
+      throw new MissingFilterPropertyException("cause", element);
+    }
+    CauseFilter.EventCause cause = CauseFilter.EventCause.getEventCause(causeProperty);
+    if (cause == null) {
+      throw new InvalidFilterPropertyException("cause", element);
+    }
+    this.cause = cause;
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/parser/ChildFilterParser.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/parser/ChildFilterParser.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.parser;
+
+import in.twizmwaz.cardinal.match.Match;
+import in.twizmwaz.cardinal.module.filter.Filter;
+import in.twizmwaz.cardinal.module.filter.FilterException;
+import in.twizmwaz.cardinal.module.filter.FilterModule;
+import in.twizmwaz.cardinal.module.filter.FilterParser;
+import in.twizmwaz.cardinal.module.filter.exception.property.MissingFilterChildException;
+import lombok.Getter;
+import org.jdom2.Element;
+
+@Getter
+public class ChildFilterParser implements FilterParser {
+
+  private final Filter child;
+
+  /**
+   * Parses an element for filters that have a single child filter.
+   *
+   * @param element The element.
+   * @throws FilterException Thrown if child filter is missing or invalid.
+   */
+  public ChildFilterParser(FilterModule filterModule, Match match, Element element) throws FilterException {
+    if (element.getChildren().size() != 1) {
+      throw new MissingFilterChildException("", element);
+    }
+    this.child = filterModule.getFilter(match, element.getChildren().get(0));
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/parser/ChildrenFilterParser.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/parser/ChildrenFilterParser.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.parser;
+
+import com.google.common.collect.Lists;
+import in.twizmwaz.cardinal.match.Match;
+import in.twizmwaz.cardinal.module.filter.Filter;
+import in.twizmwaz.cardinal.module.filter.FilterException;
+import in.twizmwaz.cardinal.module.filter.FilterModule;
+import in.twizmwaz.cardinal.module.filter.FilterParser;
+import in.twizmwaz.cardinal.module.filter.exception.property.MissingFilterChildException;
+import lombok.Getter;
+import org.jdom2.Element;
+
+import java.util.List;
+
+@Getter
+public class ChildrenFilterParser implements FilterParser {
+
+  private final List<Filter> children;
+
+  /**
+   * Parses an element for filters that have multiple child filters.
+   *
+   * @param element The element.
+   * @throws FilterException Thrown if no child filter is found, or child filters throw errors when parsed.
+   */
+  public ChildrenFilterParser(FilterModule filterModule, Match match, Element element) throws FilterException {
+    if (element.getChildren().size() == 0) {
+      throw new MissingFilterChildException("", element);
+    }
+    children = Lists.newArrayList();
+    for (Element child : element.getChildren()) {
+      children.add(filterModule.getFilter(match, child));
+    }
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/parser/ItemFilterParser.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/parser/ItemFilterParser.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.parser;
+
+import in.twizmwaz.cardinal.module.filter.FilterException;
+import in.twizmwaz.cardinal.module.filter.exception.property.MissingFilterChildException;
+import in.twizmwaz.cardinal.util.document.DocumentItems;
+import lombok.Getter;
+import org.bukkit.inventory.ItemStack;
+import org.jdom2.Element;
+
+@Getter
+public class ItemFilterParser {
+
+  private final ItemStack item;
+
+  /**
+   * Parses an element for filter that hold an item, like Carrying, Holding or Wearing filters.
+   *
+   * @param element The element.
+   * @throws FilterException Thrown if the block property is missing or invalid.
+   */
+  public ItemFilterParser(Element element) throws FilterException {
+    if (element.getChild("item") ==  null) {
+      //Fixme: needs descriptive exception
+      throw new MissingFilterChildException("item", element);
+    }
+    item = DocumentItems.getItem(element.getChild("item"));
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/parser/LayerFilterParser.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/parser/LayerFilterParser.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.parser;
+
+import in.twizmwaz.cardinal.module.filter.FilterException;
+import in.twizmwaz.cardinal.module.filter.exception.property.InvalidFilterPropertyException;
+import in.twizmwaz.cardinal.module.filter.exception.property.MissingFilterPropertyException;
+import in.twizmwaz.cardinal.module.filter.type.LayerFilter;
+import in.twizmwaz.cardinal.util.Numbers;
+import in.twizmwaz.cardinal.util.Strings;
+import lombok.Getter;
+import org.jdom2.Element;
+
+@Getter
+public class LayerFilterParser {
+
+  private final int layer;
+  private final LayerFilter.Coordinate coordinate;
+
+  /**
+   * Parses an element for a layer filter.
+   *
+   * @param element The element.
+   * @throws FilterException Thrown if layer or coordinate are missing or invalid.
+   */
+  public LayerFilterParser(Element element) throws FilterException {
+    if (element.getAttribute("layer") == null) {
+      throw new MissingFilterPropertyException("layer", element);
+    }
+    layer = Numbers.parseInteger(element.getAttributeValue("layer"));
+    String coordinateProperty = element.getAttributeValue("coordinate");
+    if (coordinateProperty == null) {
+      throw new MissingFilterPropertyException("coordinate", element);
+    }
+    try {
+      coordinate = LayerFilter.Coordinate.valueOf(Strings.getTechnicalName(coordinateProperty));
+    } catch (IllegalArgumentException e) {
+      throw new InvalidFilterPropertyException("coordinate", element);
+    }
+  }
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/parser/ObjectiveFilterParser.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/parser/ObjectiveFilterParser.java
@@ -25,6 +25,7 @@
 
 package in.twizmwaz.cardinal.module.filter.parser;
 
+import in.twizmwaz.cardinal.match.Match;
 import in.twizmwaz.cardinal.module.filter.FilterException;
 import in.twizmwaz.cardinal.module.filter.FilterParser;
 import in.twizmwaz.cardinal.module.filter.exception.property.InvalidFilterPropertyException;
@@ -44,13 +45,12 @@ public class ObjectiveFilterParser implements FilterParser {
    * @param element The element.
    * @throws FilterException Thrown if the objective property is missing or invalid.
    */
-  public ObjectiveFilterParser(Element element) throws FilterException {
+  public ObjectiveFilterParser(Element element, Match match) throws FilterException {
     String objectiveProperty = element.getText();
     if (objectiveProperty == null) {
       throw new MissingFilterPropertyException("objective", element);
     }
-    //TODO: Get objective by id
-    Objective objective = null;
+    Objective objective = Objective.getObjectiveById(match, objectiveProperty);
     if (objective == null) {
       throw new InvalidFilterPropertyException("objective", element);
     }

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/parser/RangeFilterParser.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/parser/RangeFilterParser.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.parser;
+
+import in.twizmwaz.cardinal.match.Match;
+import in.twizmwaz.cardinal.module.filter.FilterException;
+import in.twizmwaz.cardinal.module.filter.FilterModule;
+import in.twizmwaz.cardinal.util.Numbers;
+import in.twizmwaz.cardinal.util.ParseUtil;
+import lombok.Getter;
+import org.jdom2.Element;
+
+@Getter
+public class RangeFilterParser extends ChildrenFilterParser {
+
+  private final int min;
+  private final int max;
+
+  /**
+   * Parses an element for a range filter.
+   *
+   * @param element The element.
+   * @throws FilterException Thrown if child filters are missing or invalid.
+   */
+  public RangeFilterParser(FilterModule filterModule, Match match, Element element) throws FilterException {
+    super(filterModule, match, element);
+    min = Numbers.parseInteger(ParseUtil.getFirstAttribute("min", element), 0);
+    max = Numbers.parseInteger(ParseUtil.getFirstAttribute("max", element), Integer.MAX_VALUE);
+  }
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/AgnosticFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/AgnosticFilter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.type;
+
+import in.twizmwaz.cardinal.module.filter.Filter;
+import in.twizmwaz.cardinal.module.filter.FilterState;
+
+public abstract class AgnosticFilter implements Filter {
+
+  public abstract FilterState evaluate();
+
+  @Override
+  public FilterState evaluate(Object... objects) {
+    return evaluate();
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/CanFlyFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/CanFlyFilter.java
@@ -25,13 +25,18 @@
 
 package in.twizmwaz.cardinal.module.filter.type;
 
-import in.twizmwaz.cardinal.module.filter.Filter;
 import org.bukkit.entity.Player;
 
-public class CanFlyFilter implements Filter<Player> {
+public class CanFlyFilter extends ObjectTypeFilter<Player> {
 
   @Override
-  public boolean evaluate(Player evaluating) {
+  public Class<Player> getType() {
+    return Player.class;
+  }
+
+  @Override
+  public Boolean evaluate(Player evaluating) {
     return evaluating.getAllowFlight();
   }
+
 }

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/CarryingFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/CarryingFilter.java
@@ -25,18 +25,22 @@
 
 package in.twizmwaz.cardinal.module.filter.type;
 
-import in.twizmwaz.cardinal.module.filter.Filter;
 import lombok.AllArgsConstructor;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 @AllArgsConstructor
-public class CarryingFilter implements Filter<Player> {
+public class CarryingFilter extends ObjectTypeFilter<Player> {
 
   private final ItemStack item;
 
   @Override
-  public boolean evaluate(Player evaluating) {
+  public Class<Player> getType() {
+    return Player.class;
+  }
+
+  @Override
+  public Boolean evaluate(Player evaluating) {
     return evaluating.getInventory().contains(item);
   }
 

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/CauseFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/CauseFilter.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.type;
+
+import lombok.AllArgsConstructor;
+import org.bukkit.entity.Creature;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Event;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockDamageEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.world.WorldEvent;
+
+@AllArgsConstructor
+public class CauseFilter extends ObjectTypeFilter<Event> {
+
+  private final EventCause cause;
+
+  @Override
+  public Class<Event> getType() {
+    return Event.class;
+  }
+
+  @Override
+  public Boolean evaluate(Event event) {
+    if (!(event instanceof EntityDamageEvent)) {
+      switch (cause) {
+        /* Actor Type */
+        case WORLD:
+          return event instanceof WorldEvent;
+        case LIVING:
+          return event instanceof EntityEvent && ((EntityEvent) event).getEntity() instanceof LivingEntity;
+        case MOB:
+          return event instanceof EntityEvent && ((EntityEvent) event).getEntity() instanceof Creature;
+        case PLAYER:
+          return event instanceof PlayerEvent;
+        /* Block action */
+        case PUNCH:
+          return event instanceof BlockDamageEvent;
+        case TRAMPLE:
+          return event instanceof PlayerMoveEvent;
+        case MINE:
+          return event instanceof BlockBreakEvent;
+
+        case EXPLOSION:
+          return event instanceof EntityExplodeEvent;
+
+        default:
+          return null;
+      }
+    } else {
+      /* Damage Type */
+      EntityDamageEvent.DamageCause damageCause = ((EntityDamageEvent) event).getCause();
+      switch (cause) {
+        case MELEE:
+          return damageCause.equals(EntityDamageEvent.DamageCause.ENTITY_ATTACK);
+        case PROJECTILE:
+          return damageCause.equals(EntityDamageEvent.DamageCause.PROJECTILE);
+        case POTION:
+          return damageCause.equals(EntityDamageEvent.DamageCause.MAGIC)
+              || damageCause.equals(EntityDamageEvent.DamageCause.POISON)
+              || damageCause.equals(EntityDamageEvent.DamageCause.WITHER)
+              || damageCause.equals(EntityDamageEvent.DamageCause.DRAGON_BREATH);
+        case EXPLOSION:
+          return damageCause.equals(EntityDamageEvent.DamageCause.BLOCK_EXPLOSION)
+              || damageCause.equals(EntityDamageEvent.DamageCause.ENTITY_EXPLOSION);
+        case COMBUSTION:
+          return damageCause.equals(EntityDamageEvent.DamageCause.FIRE)
+              || damageCause.equals(EntityDamageEvent.DamageCause.FIRE_TICK)
+              || damageCause.equals(EntityDamageEvent.DamageCause.MELTING)
+              || damageCause.equals(EntityDamageEvent.DamageCause.LAVA)
+              || damageCause.equals(EntityDamageEvent.DamageCause.HOT_FLOOR);
+        case FALL:
+          return damageCause.equals(EntityDamageEvent.DamageCause.FALL);
+        case GRAVITY:
+          return damageCause.equals(EntityDamageEvent.DamageCause.FALL)
+              || damageCause.equals(EntityDamageEvent.DamageCause.VOID);
+        case VOID:
+          return damageCause.equals(EntityDamageEvent.DamageCause.VOID);
+        case SQUASH:
+          return damageCause.equals(EntityDamageEvent.DamageCause.FALLING_BLOCK);
+        case SUFFOCATION:
+          return damageCause.equals(EntityDamageEvent.DamageCause.SUFFOCATION);
+        case DROWNING:
+          return damageCause.equals(EntityDamageEvent.DamageCause.DROWNING);
+        case STARVATION:
+          return damageCause.equals(EntityDamageEvent.DamageCause.STARVATION);
+        case LIGHTNING:
+          return damageCause.equals(EntityDamageEvent.DamageCause.LIGHTNING);
+        case CACTUS:
+          return damageCause.equals(EntityDamageEvent.DamageCause.CONTACT);
+        case THORNS:
+          return damageCause.equals(EntityDamageEvent.DamageCause.THORNS);
+
+        default:
+          return null;
+      }
+    }
+  }
+
+  public enum EventCause {
+    /* Actor Type */
+    WORLD(),
+    LIVING(),
+    MOB(),
+    PLAYER(),
+    /* Block action */
+    PUNCH(),
+    TRAMPLE(),
+    MINE(),
+    /* Damage Type */
+    MELEE(),
+    PROJECTILE(),
+    POTION(),
+    EXPLOSION(),
+    COMBUSTION(),
+    FALL(),
+    GRAVITY(),
+    VOID(),
+    SQUASH(),
+    SUFFOCATION(),
+    DROWNING(),
+    STARVATION(),
+    LIGHTNING(),
+    CACTUS(),
+    THORNS();
+
+    /**
+     * Gets an event cause by a string
+     * @param string The cause name
+     * @return An event cause that matches that name, null if none were found.
+     */
+    public static EventCause getEventCause(String string) {
+      switch (string.toLowerCase().replaceAll(" ", "")) {
+        case "world":
+          return WORLD;
+        case "living":
+          return LIVING;
+        case "mob":
+          return MOB;
+        case "player":
+          return PLAYER;
+        case "punch":
+          return PUNCH;
+        case "trample":
+          return TRAMPLE;
+        case "mine":
+          return MINE;
+        case "melee":
+          return MELEE;
+        case "projectile":
+          return PROJECTILE;
+        case "potion":
+          return POTION;
+        case "tnt":
+        case "explosion":
+          return EXPLOSION;
+        case "combustion":
+          return COMBUSTION;
+        case "fall":
+          return FALL;
+        case "gravity":
+          return GRAVITY;
+        case "void":
+          return VOID;
+        case "squash":
+          return SQUASH;
+        case "suffocation":
+          return SUFFOCATION;
+        case "drowning":
+          return DROWNING;
+        case "starvation":
+          return STARVATION;
+        case "lightning":
+          return LIGHTNING;
+        case "cactus":
+          return CACTUS;
+        case "thorns":
+          return THORNS;
+        default:
+          return null;
+      }
+    }
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/CreatureFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/CreatureFilter.java
@@ -23,7 +23,21 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package in.twizmwaz.cardinal.module.filter.parser;
+package in.twizmwaz.cardinal.module.filter.type;
 
-public class CarryingFilterParser {
+import org.bukkit.entity.Creature;
+import org.bukkit.entity.Entity;
+
+public class CreatureFilter extends ObjectTypeFilter<Entity> {
+
+  @Override
+  public Class<Entity> getType() {
+    return Entity.class;
+  }
+
+  @Override
+  public Boolean evaluate(Entity entity) {
+    return entity instanceof Creature;
+  }
+
 }

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/CrouchingFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/CrouchingFilter.java
@@ -25,13 +25,18 @@
 
 package in.twizmwaz.cardinal.module.filter.type;
 
-import in.twizmwaz.cardinal.module.filter.Filter;
 import org.bukkit.entity.Player;
 
-public class CrouchingFilter implements Filter<Player> {
+public class CrouchingFilter extends ObjectTypeFilter<Player> {
 
   @Override
-  public boolean evaluate(Player evaluating) {
+  public Class<Player> getType() {
+    return Player.class;
+  }
+
+  @Override
+  public Boolean evaluate(Player evaluating) {
     return evaluating.isSneaking();
   }
+
 }

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/EntityFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/EntityFilter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.type;
+
+import in.twizmwaz.cardinal.module.filter.FilterState;
+import lombok.AllArgsConstructor;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+
+@AllArgsConstructor
+public class EntityFilter extends SingleObjectFilter {
+
+  private final EntityType entityType;
+
+  @Override
+  public FilterState evaluate(Object evaluating) {
+    if (evaluating instanceof Entity) {
+      return FilterState.fromBoolean(((Entity) evaluating).getType().equals(entityType));
+    } else if (evaluating instanceof EntityType) {
+      return FilterState.fromBoolean(entityType.equals(evaluating));
+    } else if (evaluating instanceof CreatureSpawnEvent) {
+      return FilterState.fromBoolean(((CreatureSpawnEvent) evaluating).getEntity().getType().equals(entityType));
+    }
+    return FilterState.ABSTAIN;
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/FlyingFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/FlyingFilter.java
@@ -25,13 +25,18 @@
 
 package in.twizmwaz.cardinal.module.filter.type;
 
-import in.twizmwaz.cardinal.module.filter.Filter;
 import org.bukkit.entity.Player;
 
-public class FlyingFilter implements Filter<Player> {
+public class FlyingFilter extends ObjectTypeFilter<Player> {
 
   @Override
-  public boolean evaluate(Player evaluating) {
+  public Class<Player> getType() {
+    return Player.class;
+  }
+
+  @Override
+  public Boolean evaluate(Player evaluating) {
     return evaluating.isFlying();
   }
+
 }

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/HoldingFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/HoldingFilter.java
@@ -25,18 +25,22 @@
 
 package in.twizmwaz.cardinal.module.filter.type;
 
-import in.twizmwaz.cardinal.module.filter.Filter;
 import lombok.AllArgsConstructor;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 @AllArgsConstructor
-public class HoldingFilter implements Filter<Player> {
+public class HoldingFilter extends ObjectTypeFilter<Player> {
 
   private final ItemStack item;
 
   @Override
-  public boolean evaluate(Player evaluating) {
+  public Class<Player> getType() {
+    return Player.class;
+  }
+
+  @Override
+  public Boolean evaluate(Player evaluating) {
     return evaluating.getInventory().getItemInMainHand().isSimilar(item);
   }
 

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/LayerFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/LayerFilter.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.type;
+
+import lombok.AllArgsConstructor;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+
+@AllArgsConstructor
+public class LayerFilter extends ObjectTypeFilter<Block> {
+
+  private final int layer;
+  private final Coordinate coordinate;
+
+  @Override
+  public Class<Block> getType() {
+    return Block.class;
+  }
+
+  @Override
+  public Boolean evaluate(Block block) {
+    return getCoord(block) == layer
+        || block.getWorld().getBlockAt(
+        layerOrBlock(Coordinate.X, block.getX()),
+        layerOrBlock(Coordinate.Y, block.getY()),
+        layerOrBlock(Coordinate.Z, block.getZ())).getType().equals(Material.AIR);
+  }
+
+  private int layerOrBlock(Coordinate coord, int block) {
+    return coordinate.equals(coord) ? layer : block;
+  }
+
+  private int getCoord(Block block) {
+    switch (coordinate) {
+      case X:
+        return block.getX();
+      case Y:
+        return block.getY();
+      case Z:
+        return block.getZ();
+      default:
+        return 0;
+    }
+  }
+
+  public enum Coordinate {
+    X,
+    Y,
+    Z;
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/MaterialFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/MaterialFilter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.type;
+
+import in.twizmwaz.cardinal.module.filter.FilterState;
+import in.twizmwaz.cardinal.util.MaterialPattern;
+import lombok.AllArgsConstructor;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.inventory.ItemStack;
+
+@AllArgsConstructor
+public class MaterialFilter extends SingleObjectFilter {
+
+  MaterialPattern material;
+
+  @Override
+  public FilterState evaluate(Object evaluating) {
+    if (evaluating instanceof Block) {
+      Block block = (Block) evaluating;
+      return FilterState.fromBoolean(material.contains(block.getType(), block.getData()));
+    } else if (evaluating instanceof Material) {
+      return FilterState.fromBoolean(material.contains((Material) evaluating, -1));
+    } else if (evaluating instanceof ItemStack) {
+      return FilterState.fromBoolean(material.contains((ItemStack) evaluating));
+    }
+    return FilterState.ABSTAIN;
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/MonsterFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/MonsterFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.type;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Monster;
+
+public class MonsterFilter extends ObjectTypeFilter<Entity> {
+
+  @Override
+  public Class<Entity> getType() {
+    return Entity.class;
+  }
+
+  @Override
+  public Boolean evaluate(Entity entity) {
+    return entity instanceof Monster;
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/ObjectTypeFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/ObjectTypeFilter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.type;
+
+
+import in.twizmwaz.cardinal.module.filter.Filter;
+import in.twizmwaz.cardinal.module.filter.FilterState;
+
+public abstract class ObjectTypeFilter<T> implements Filter {
+
+  public abstract Class<T> getType();
+
+  public abstract Boolean evaluate(T evaluating);
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public FilterState evaluate(Object... objects) {
+    for (Object obj : objects) {
+      if (getType().isAssignableFrom(obj.getClass())) {
+        return FilterState.fromBoolean(evaluate((T) obj));
+      }
+    }
+    return FilterState.ABSTAIN;
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/RandomFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/RandomFilter.java
@@ -25,14 +25,14 @@
 
 package in.twizmwaz.cardinal.module.filter.type;
 
-import in.twizmwaz.cardinal.module.filter.Filter;
+import in.twizmwaz.cardinal.module.filter.FilterState;
 import in.twizmwaz.cardinal.module.filter.parser.RandomFilterParser;
 import lombok.AllArgsConstructor;
 
 import java.util.Random;
 
 @AllArgsConstructor
-public class RandomFilter implements Filter<Object> {
+public class RandomFilter extends AgnosticFilter {
 
   private final double chance;
 
@@ -41,8 +41,8 @@ public class RandomFilter implements Filter<Object> {
   }
 
   @Override
-  public boolean evaluate(Object fg) {
-    return new Random().nextDouble() <= chance;
+  public FilterState evaluate() {
+    return FilterState.fromBoolean(new Random().nextDouble() <= chance);
   }
 
 }

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/SameTeamFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/SameTeamFilter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.type;
+
+import in.twizmwaz.cardinal.Cardinal;
+import in.twizmwaz.cardinal.module.filter.Filter;
+import in.twizmwaz.cardinal.module.filter.FilterState;
+import in.twizmwaz.cardinal.playercontainer.PlayingPlayerContainer;
+import lombok.AllArgsConstructor;
+import org.bukkit.entity.Player;
+
+@AllArgsConstructor
+public class SameTeamFilter extends ObjectTypeFilter<Player> {
+
+  Filter child;
+
+  @Override
+  public Class<Player> getType() {
+    return Player.class;
+  }
+
+  @Override
+  public Boolean evaluate(Player evaluating) {
+    //fixme: Is this how you get a player's team?
+    PlayingPlayerContainer container = Cardinal.getMatch(evaluating).getPlayingContainer(evaluating);
+    for (Player player : container.getPlayers()) {
+      if (child.evaluate(player).equals(FilterState.ALLOW)) {
+        return true;
+      }
+    }
+    return null;
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/SingleObjectFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/SingleObjectFilter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.type;
+
+import in.twizmwaz.cardinal.module.filter.Filter;
+import in.twizmwaz.cardinal.module.filter.FilterState;
+
+public abstract class SingleObjectFilter implements Filter {
+
+  public abstract FilterState evaluate(Object evaluating);
+
+  @Override
+  public FilterState evaluate(Object... objects) {
+    for (Object obj : objects) {
+      FilterState response = this.evaluate(obj);
+      if (!response.equals(FilterState.ABSTAIN)) {
+        return response;
+      }
+    }
+    return FilterState.ABSTAIN;
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/SpawnFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/SpawnFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.type;
+
+import in.twizmwaz.cardinal.module.filter.FilterState;
+import lombok.AllArgsConstructor;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+
+@AllArgsConstructor
+public class SpawnFilter extends SingleObjectFilter {
+
+  private final CreatureSpawnEvent.SpawnReason spawnReason;
+
+  @Override
+  public FilterState evaluate(Object evaluating) {
+    if (evaluating instanceof CreatureSpawnEvent) {
+      return FilterState.fromBoolean(((CreatureSpawnEvent) evaluating).getSpawnReason().equals(spawnReason));
+    } else if (evaluating instanceof CreatureSpawnEvent.SpawnReason) {
+      return FilterState.fromBoolean(spawnReason.equals(evaluating));
+    }
+    return FilterState.ABSTAIN;
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/SprintingFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/SprintingFilter.java
@@ -25,13 +25,17 @@
 
 package in.twizmwaz.cardinal.module.filter.type;
 
-import in.twizmwaz.cardinal.module.filter.Filter;
 import org.bukkit.entity.Player;
 
-public class SprintingFilter implements Filter<Player> {
+public class SprintingFilter extends ObjectTypeFilter<Player> {
 
   @Override
-  public boolean evaluate(Player evaluating) {
+  public Class<Player> getType() {
+    return Player.class;
+  }
+
+  @Override
+  public Boolean evaluate(Player evaluating) {
     return evaluating.isSprinting();
   }
 }

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/StaticFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/StaticFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.type;
+
+import in.twizmwaz.cardinal.module.filter.FilterState;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class StaticFilter extends AgnosticFilter {
+
+  private final FilterState state;
+
+  @Override
+  public FilterState evaluate() {
+    return state;
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/TeamFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/TeamFilter.java
@@ -26,21 +26,27 @@
 package in.twizmwaz.cardinal.module.filter.type;
 
 import in.twizmwaz.cardinal.Cardinal;
-import in.twizmwaz.cardinal.module.filter.Filter;
+import in.twizmwaz.cardinal.module.filter.FilterState;
 import in.twizmwaz.cardinal.module.team.Team;
 import in.twizmwaz.cardinal.playercontainer.PlayingPlayerContainer;
 import lombok.AllArgsConstructor;
 import org.bukkit.entity.Player;
 
 @AllArgsConstructor
-public class TeamFilter implements Filter<Player> {
+public class TeamFilter extends SingleObjectFilter {
 
   private final Team team;
 
   @Override
-  public boolean evaluate(Player evaluating) {
-    PlayingPlayerContainer container = Cardinal.getMatch(evaluating).getPlayingContainer(evaluating);
-    return container != null && team.equals(container);
+  public FilterState evaluate(Object evaluating) {
+    if (evaluating instanceof Team) {
+      return FilterState.fromBoolean(team.equals(evaluating));
+    } else if (evaluating instanceof Player) {
+      PlayingPlayerContainer container =
+          Cardinal.getMatch((Player) evaluating).getPlayingContainer((Player) evaluating);
+      return FilterState.fromBoolean(container != null && team.equals(container));
+    }
+    return FilterState.ABSTAIN;
   }
 
 }

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/VoidFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/VoidFilter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.type;
+
+public class VoidFilter extends LayerFilter {
+
+  public VoidFilter() {
+    super(0, Coordinate.Y);
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/WalkingFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/WalkingFilter.java
@@ -25,14 +25,18 @@
 
 package in.twizmwaz.cardinal.module.filter.type;
 
-import in.twizmwaz.cardinal.module.filter.Filter;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
-public class WalkingFilter implements Filter<Player> {
+public class WalkingFilter extends ObjectTypeFilter<Player> {
 
   @Override
-  public boolean evaluate(Player evaluating) {
+  public Class<Player> getType() {
+    return Player.class;
+  }
+
+  @Override
+  public Boolean evaluate(Player evaluating) {
     Vector velocity = evaluating.getVelocity();
     return velocity.length() != 0 && velocity.getY() == 0 && !evaluating.isSprinting();
   }

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/WearingFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/WearingFilter.java
@@ -25,18 +25,22 @@
 
 package in.twizmwaz.cardinal.module.filter.type;
 
-import in.twizmwaz.cardinal.module.filter.Filter;
 import lombok.AllArgsConstructor;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 @AllArgsConstructor
-public class WearingFilter implements Filter<Player> {
+public class WearingFilter extends ObjectTypeFilter<Player> {
 
   private final ItemStack item;
 
   @Override
-  public boolean evaluate(Player evaluating) {
+  public Class<Player> getType() {
+    return Player.class;
+  }
+
+  @Override
+  public Boolean evaluate(Player evaluating) {
     for (ItemStack wearing : evaluating.getInventory().getArmorContents()) {
       if (item.isSimilar(wearing)) {
         return true;

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/modifiers/AllFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/modifiers/AllFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.type.modifiers;
+
+import com.google.common.collect.Lists;
+import in.twizmwaz.cardinal.module.filter.Filter;
+
+import java.util.List;
+
+public class AllFilter extends RangeFilter {
+
+  public AllFilter(Filter... children) {
+    this(Lists.newArrayList(children));
+  }
+
+  public AllFilter(List<Filter> children) {
+    super(children, children.size(), children.size());
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/modifiers/AllowFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/modifiers/AllowFilter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.type.modifiers;
+
+import in.twizmwaz.cardinal.Cardinal;
+import in.twizmwaz.cardinal.match.Match;
+import in.twizmwaz.cardinal.module.filter.Filter;
+import in.twizmwaz.cardinal.module.filter.FilterModule;
+import in.twizmwaz.cardinal.module.filter.FilterState;
+import in.twizmwaz.cardinal.module.filter.LoadLateFilter;
+import lombok.AllArgsConstructor;
+
+import java.util.Collections;
+
+@AllArgsConstructor
+public class AllowFilter implements Filter, LoadLateFilter {
+
+  private final Filter child;
+
+  @Override
+  public void load(Match match) {
+    Cardinal.getModule(FilterModule.class).loadFilters(match, Collections.singleton(child));
+  }
+
+  @Override
+  public FilterState evaluate(Object... objects) {
+    FilterState response = child.evaluate(objects);
+    return response.equals(FilterState.ALLOW) ? response : FilterState.ABSTAIN;
+
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/modifiers/AnyFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/modifiers/AnyFilter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.type.modifiers;
+
+import com.google.common.collect.Lists;
+import in.twizmwaz.cardinal.module.filter.Filter;
+
+import java.util.List;
+
+public class AnyFilter extends RangeFilter {
+
+
+  public AnyFilter(Filter... children) {
+    this(Lists.newArrayList(children));
+  }
+
+  public AnyFilter(List<Filter> children) {
+    super(children, 1, children.size());
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/modifiers/DenyFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/modifiers/DenyFilter.java
@@ -23,18 +23,33 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package in.twizmwaz.cardinal.module.filter.type;
+package in.twizmwaz.cardinal.module.filter.type.modifiers;
 
+import in.twizmwaz.cardinal.Cardinal;
+import in.twizmwaz.cardinal.match.Match;
 import in.twizmwaz.cardinal.module.filter.Filter;
+import in.twizmwaz.cardinal.module.filter.FilterModule;
+import in.twizmwaz.cardinal.module.filter.FilterState;
+import in.twizmwaz.cardinal.module.filter.LoadLateFilter;
 import lombok.AllArgsConstructor;
 
-@AllArgsConstructor
-public class SingletonFilter<T> implements Filter<T> {
+import java.util.Collections;
 
-  private final T object;
+@AllArgsConstructor
+public class DenyFilter implements Filter, LoadLateFilter {
+
+  private final Filter child;
 
   @Override
-  public boolean evaluate(T evaluating) {
-    return object.equals(evaluating);
+  public void load(Match match) {
+    Cardinal.getModule(FilterModule.class).loadFilters(match, Collections.singleton(child));
   }
+
+  @Override
+  public FilterState evaluate(Object... objects) {
+    FilterState response = child.evaluate(objects);
+    return response.equals(FilterState.ALLOW) ? FilterState.DENY : FilterState.ABSTAIN;
+
+  }
+
 }

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/modifiers/NotFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/modifiers/NotFilter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.type.modifiers;
+
+import in.twizmwaz.cardinal.Cardinal;
+import in.twizmwaz.cardinal.match.Match;
+import in.twizmwaz.cardinal.module.filter.Filter;
+import in.twizmwaz.cardinal.module.filter.FilterModule;
+import in.twizmwaz.cardinal.module.filter.FilterState;
+import in.twizmwaz.cardinal.module.filter.LoadLateFilter;
+import lombok.AllArgsConstructor;
+
+import java.util.Collections;
+
+@AllArgsConstructor
+public class NotFilter implements Filter, LoadLateFilter {
+
+  private final Filter child;
+
+  @Override
+  public void load(Match match) {
+    Cardinal.getModule(FilterModule.class).loadFilters(match, Collections.singleton(child));
+  }
+
+  @Override
+  public FilterState evaluate(Object... objects) {
+    FilterState response = child.evaluate(objects);
+    return response.equals(FilterState.ABSTAIN) ? response :
+        FilterState.fromBoolean(response.equals(FilterState.DENY));
+
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/modifiers/OneFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/modifiers/OneFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.type.modifiers;
+
+import com.google.common.collect.Lists;
+import in.twizmwaz.cardinal.module.filter.Filter;
+
+import java.util.List;
+
+public class OneFilter extends RangeFilter {
+
+  public OneFilter(Filter... children) {
+    this(Lists.newArrayList(children));
+  }
+
+  public OneFilter(List<Filter> children) {
+    super(children, 1, 1);
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/filter/type/modifiers/RangeFilter.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/filter/type/modifiers/RangeFilter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.module.filter.type.modifiers;
+
+import com.google.common.collect.Lists;
+import in.twizmwaz.cardinal.Cardinal;
+import in.twizmwaz.cardinal.match.Match;
+import in.twizmwaz.cardinal.module.filter.Filter;
+import in.twizmwaz.cardinal.module.filter.FilterModule;
+import in.twizmwaz.cardinal.module.filter.FilterState;
+import in.twizmwaz.cardinal.module.filter.LoadLateFilter;
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+public class RangeFilter implements Filter, LoadLateFilter {
+
+  private final List<Filter> children;
+  private final int min;
+  private final int max;
+
+
+  public RangeFilter(int min, int max, Filter... children) {
+    this(Lists.newArrayList(children), min, max);
+  }
+
+  @Override
+  public void load(Match match) {
+    Cardinal.getModule(FilterModule.class).loadFilters(match, children);
+  }
+
+  @Override
+  public FilterState evaluate(Object... objects) {
+    int[] states = new int[]{0, 0, 0};
+    for (int i = 0; i < children.size(); i++) {
+      states[children.get(i).evaluate(objects).ordinal()]++;
+      if ((states[1] + states[2] > children.size() - min && states[0] + states[1] > 0) /* Can't reach min anymore */
+          || states[0] > max /* Allow bigger than max */ ) {
+        return FilterState.DENY;
+      }
+      if (states[0] >= min && states[0] + (children.size() - 1 - i) >= max) { /* Won't go bigger than max */
+        return FilterState.ALLOW;
+      }
+    }
+    return states[0] >= min ? FilterState.ALLOW : FilterState.ABSTAIN;
+  }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/kit/KitModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/kit/KitModule.java
@@ -47,25 +47,14 @@ import in.twizmwaz.cardinal.module.kit.type.KitKnockback;
 import in.twizmwaz.cardinal.module.kit.type.KitPotion;
 import in.twizmwaz.cardinal.module.kit.type.KitWalkSpeed;
 import in.twizmwaz.cardinal.util.ArmorType;
-import in.twizmwaz.cardinal.util.Colors;
 import in.twizmwaz.cardinal.util.Numbers;
 import in.twizmwaz.cardinal.util.Strings;
+import in.twizmwaz.cardinal.util.document.DocumentItems;
 import lombok.Getter;
-import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
-import org.bukkit.Material;
 import org.bukkit.attribute.AttributeModifier;
-import org.bukkit.attribute.ItemAttributeModifier;
-import org.bukkit.enchantments.Enchantment;
-import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.BookMeta;
-import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.inventory.meta.LeatherArmorMeta;
-import org.bukkit.inventory.meta.PotionMeta;
-import org.bukkit.potion.Potion;
 import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 import org.jdom2.Element;
 
 import java.util.AbstractMap;
@@ -87,330 +76,107 @@ public class KitModule extends AbstractModule {
     Map<String, Kit> matchKits = kits.get(match);
     for (Element kits : match.getMap().getDocument().getRootElement().getChildren("kits")) {
       for (Element element : kits.getChildren("kit")) {
-        Map.Entry<String, Kit> entry = parseKit(match, element, true);
+        Map.Entry<String, Kit> entry = parseKit(match, element);
         matchKits.put(entry.getKey(), entry.getValue());
       }
     }
-
     return true;
   }
 
-  private Map.Entry<String, Kit> parseKit(Match match, Element element, boolean forceParse) {
-    if (element.getName().equalsIgnoreCase("kit") || forceParse) {
-      List<Kit> kits = Lists.newArrayList();
-      String name = null;
-      if (element.getAttributeValue("name") != null) {
-        name = element.getAttributeValue("name");
-      }
-      if (element.getAttributeValue("id") != null) {
-        name = element.getAttributeValue("id");
-      }
-      for (Map.Entry<String, Kit> kitPair : this.kits.get(match).entrySet()) {
-        if (kitPair.getKey().equalsIgnoreCase(name)) {
-          return kitPair;
-        }
-      }
-
-      boolean clear = element.getChildren("clear").size() > 0;
-      boolean clearItems = element.getChildren("clear-items").size() > 0;
-      if (clear || clearItems) {
-        kits.add(new KitClear(clear, clearItems));
-      }
-
-      Set<KitItem.Item> items = Sets.newHashSet();
-      items.addAll(element.getChildren("item").stream().map(KitModule::getKitItem).collect(Collectors.toList()));
-      if (!items.isEmpty()) {
-        kits.add(new KitItem(items));
-      }
-
-      Set<KitArmor.Armor> armor = Sets.newHashSet();
-      List<Element> armors = Lists.newArrayList();
-      Lists.newArrayList(ArmorType.values()).forEach(type -> armors.addAll(element.getChildren(type.name())));
-      for (Element piece : armors) {
-        ItemStack itemStack = getItem(piece);
-        ArmorType type = ArmorType.valueOf(piece.getName());
-        Boolean locked = Numbers.parseBoolean(element.getAttributeValue("locked"));
-        armor.add(new KitArmor.Armor(itemStack, type, locked));
-      }
-      if (!armor.isEmpty()) {
-        kits.add(new KitArmor(armor));
-      }
-
-      if (element.getChildText("game-mode") != null) {
-        GameMode gameMode = GameMode.valueOf(element.getChildText("game-mode").toUpperCase());
-        if (gameMode != null) {
-          kits.add(new KitGameMode(gameMode));
-        }
-      }
-      int health = Numbers.parseInteger(element.getChildText("health"), -1);
-      int foodLevel = Numbers.parseInteger(element.getChildText("foodlevel"), -1);
-      float saturation = Numbers.parseInteger(element.getChildText("saturation"), 0);
-      if (health != -1 || foodLevel != -1 || saturation != 0) {
-        kits.add(new KitHealth(health, foodLevel, saturation));
-      }
-
-      List<PotionEffect> potions = Lists.newArrayList();
-      potions.addAll(element.getChildren("potion").stream().map(KitModule::getPotion).collect(Collectors.toList()));
-      potions.addAll(element.getChildren("effect").stream().map(KitModule::getPotion).collect(Collectors.toList()));
-      if (!potions.isEmpty()) {
-        kits.add(new KitPotion(potions));
-      }
-
-      Set<AttributeModifier> attributes = Sets.newHashSet();
-      attributes.addAll(element.getChildren("attribute").stream().map(attr -> new AttributeModifier(
-          UUID.randomUUID(), attr.getText(),
-          Double.parseDouble(attr.getAttributeValue("amount", "0.0")),
-          getOperation(attr.getAttributeValue("operation", "add")))).collect(Collectors.toList()));
-      if (!attributes.isEmpty()) {
-        kits.add(new KitAttribute(attributes));
-      }
-
-
-      if (element.getChildText("walk-speed") != null) {
-        kits.add(new KitWalkSpeed(Float.parseFloat(element.getChildText("walk-speed")) / 5));
-      }
-      if (element.getChildText("knockback-reduction") != null) {
-        kits.add(new KitKnockback(Float.parseFloat(element.getChildText("knockback-reduction"))));
-      }
-
-      for (Element jump : element.getChildren("double-jump")) {
-        boolean enabled = Numbers.parseBoolean(jump.getAttributeValue("enabled"), true);
-        int power = Numbers.parseInteger(jump.getAttributeValue("power"), 3);
-        double rechargeTime = Strings.timeStringToExactSeconds(jump.getAttributeValue("recharge-time", "2.5s"));
-        boolean rechargeBeforeLand = Numbers.parseBoolean(jump.getAttributeValue("recharge-before-landing"), false);
-        kits.add(new KitDoubleJump(new KitDoubleJump.DoubleJumpData(enabled, power, rechargeTime, rechargeBeforeLand)));
-      }
-
-      for (Element jump : element.getChildren("fly")) {
-        boolean canFly = Numbers.parseBoolean(jump.getAttributeValue("can-fly"), true);
-        boolean flying = Numbers.parseBoolean(jump.getAttributeValue("flying"), false);
-        float flySpeed = Float.parseFloat(jump.getAttributeValue("fly-speed", "1")) / 10F;
-        kits.add(new KitFly(canFly, flying, flySpeed));
-      }
-
-      Filter filter = Cardinal.getModule(FilterModule.class)
-          .getFilter(match, element.getAttributeValue("filter", "always"));
-      String parent = element.getAttributeValue("parents", "");
-      List<String> parents = Lists.newArrayList();
-      for (String parentPart : parent.split(",")) {
-        parents.add(parentPart.trim());
-      }
-      boolean force = Numbers.parseBoolean(element.getAttributeValue("force"), false);
-      boolean potionParticles = Numbers.parseBoolean(element.getAttributeValue("potion-particles"), false);
-      boolean discardPotionBottles = Numbers.parseBoolean(element.getAttributeValue("discard-potion-bottles"), true);
-      boolean resetPearls = Numbers.parseBoolean(element.getAttributeValue("reset-ender-pearls"), false);
-      return new AbstractMap.SimpleEntry<>(name,
-          new KitCluster(match, filter, force, potionParticles, discardPotionBottles, resetPearls, parents, kits));
-    } else {
-      return parseKit(match, element.getParentElement(), true);
-    }
-  }
-
-  private static KitItem.Item getKitItem(Element element) {
-    ItemStack itemStack = getItem(element);
-    int slot = -1;
-    String slotString = element.getAttributeValue("slot", "-1");
-    if (Numbers.isNumber(slotString)) {
-      slot = Integer.parseInt(slotString);
-    } else {
-      if (!slotString.startsWith("slot.")) {
-        slotString = "slot." + slotString;
-        //TODO: get an int from the slot WITHOUT unnecessary NMS.
-      }
-    }
-    return new KitItem.Item(itemStack, slot);
-  }
-
-  private static ItemStack getItem(Element element) {
-    int amount = Numbers.parseInteger(element.getAttributeValue("amount", "1"));
-    short damage = element.getAttributeValue("damage") != null
-        ? Numbers.parseShort(element.getAttributeValue("damage"))
-        : element.getText().split(":").length > 1
-        ? Numbers.parseShort(element.getText().split(":")[1], (short) 0)
-        : 0;
-    ItemStack itemStack = new ItemStack(Material.AIR);
-    if (element.getAttribute("material") != null) {
-      itemStack = new ItemStack(Material.matchMaterial(element.getAttributeValue("material")), amount, damage);
-    } else if (!element.getTextTrim().equals("")) {
-      itemStack = new ItemStack(Material.matchMaterial(element.getText().split(":")[0]), amount, damage);
-    }
-    if (itemStack.getType() == Material.POTION) {
-      itemStack = Potion.fromDamage(damage).toItemStack(amount);
-    }
-    if (element.getName().equalsIgnoreCase("book")) {
-      itemStack = new ItemStack(Material.BOOK, amount, damage);
-    }
-    if (element.getAttributeValue("enchantment") != null) {
-      for (String raw : element.getAttributeValue("enchantment").split(";")) {
-        String[] enchant = raw.split(":");
-        int lvl = enchant.length > 1 ? Numbers.parseInteger(enchant[1]) : 1;
-        Enchantment enchantment = Enchantment.getByName(Strings.getTechnicalName(enchant[0]));
-        if (enchantment == null) {
-          //TODO: NMS enchantment names
-        } else {
-          itemStack.addUnsafeEnchantment(Enchantment.getByName(Strings.getTechnicalName(enchant[0])), lvl);
-        }
-      }
-    }
-    ItemMeta meta = itemStack.getItemMeta();
-    if (Numbers.parseBoolean(element.getAttributeValue("unbreakable"))) {
-      meta.setUnbreakable(true);
-    }
+  private Map.Entry<String, Kit> parseKit(Match match, Element element) {
+    List<Kit> kits = Lists.newArrayList();
+    String name = null;
     if (element.getAttributeValue("name") != null) {
-      meta.setDisplayName(ChatColor.translateAlternateColorCodes('`', element.getAttributeValue("name")));
+      name = element.getAttributeValue("name");
     }
-    if (element.getAttributeValue("lore") != null) {
-      List<String> lore = Lists.newArrayList();
-      for (String raw : element.getAttributeValue("lore").split("\\|")) {
-        String colored = ChatColor.translateAlternateColorCodes('`', raw);
-        lore.add(colored);
-      }
-      meta.setLore(lore);
+    if (element.getAttributeValue("id") != null) {
+      name = element.getAttributeValue("id");
     }
-    if (element.getAttributeValue("potions") != null) {
-      for (PotionEffect effect : parseEffects(element.getAttributeValue("potions"))) {
-        ((PotionMeta) meta).addCustomEffect(effect, true);
+    for (Map.Entry<String, Kit> kitPair : this.kits.get(match).entrySet()) {
+      if (kitPair.getKey().equalsIgnoreCase(name)) {
+        return kitPair;
       }
     }
-    if (element.getAttributeValue("attributes") != null) {
-      for (ItemAttributeModifier attribute : parseAttributes((element.getAttributeValue("attributes")))) {
-        meta.addAttributeModifier(attribute.getModifier().getName(), attribute);
+    boolean clear = element.getChildren("clear").size() > 0;
+    boolean clearItems = element.getChildren("clear-items").size() > 0;
+    if (clear || clearItems) {
+      kits.add(new KitClear(clear, clearItems));
+    }
+    Set<KitItem.Item> items = Sets.newHashSet();
+    items.addAll(element.getChildren("item").stream().map(DocumentItems::getKitItem).collect(Collectors.toList()));
+    if (!items.isEmpty()) {
+      kits.add(new KitItem(items));
+    }
+    Set<KitArmor.Armor> armor = Sets.newHashSet();
+    List<Element> armors = Lists.newArrayList();
+    Lists.newArrayList(ArmorType.values()).forEach(type -> armors.addAll(element.getChildren(type.name())));
+    for (Element piece : armors) {
+      ItemStack itemStack = DocumentItems.getItem(piece);
+      ArmorType type = ArmorType.valueOf(piece.getName());
+      Boolean locked = Numbers.parseBoolean(element.getAttributeValue("locked"));
+      armor.add(new KitArmor.Armor(itemStack, type, locked));
+    }
+    if (!armor.isEmpty()) {
+      kits.add(new KitArmor(armor));
+    }
+    if (element.getChildText("game-mode") != null) {
+      GameMode gameMode = GameMode.valueOf(element.getChildText("game-mode").toUpperCase());
+      if (gameMode != null) {
+        kits.add(new KitGameMode(gameMode));
       }
     }
-    for (Element attribute : element.getChildren("attribute")) {
-      meta.addAttributeModifier(attribute.getText(), getAttribute(attribute));
+    int health = Numbers.parseInteger(element.getChildText("health"), -1);
+    int foodLevel = Numbers.parseInteger(element.getChildText("foodlevel"), -1);
+    float saturation = Numbers.parseInteger(element.getChildText("saturation"), 0);
+    if (health != -1 || foodLevel != -1 || saturation != 0) {
+      kits.add(new KitHealth(health, foodLevel, saturation));
     }
-    itemStack.setItemMeta(meta);
-    if (element.getName().equalsIgnoreCase("book")) {
-      BookMeta bookMeta = (BookMeta) itemStack.getItemMeta();
-      bookMeta.setTitle(ChatColor.translateAlternateColorCodes('`', element.getChildText("author")));
-      bookMeta.setAuthor(ChatColor.translateAlternateColorCodes('`', element.getChildText("author")));
-      List<String> pages = Lists.newArrayList();
-      for (Element page : element.getChild("pages").getChildren("page")) {
-        pages.add(ChatColor.translateAlternateColorCodes('`', page.getText()).replace("\t", ""));
-      }
-      bookMeta.setPages(pages);
-      itemStack.setItemMeta(bookMeta);
+    List<PotionEffect> potions = Lists.newArrayList();
+    potions.addAll(element.getChildren("potion").stream().map(DocumentItems::getPotion).collect(Collectors.toList()));
+    potions.addAll(element.getChildren("effect").stream().map(DocumentItems::getPotion).collect(Collectors.toList()));
+    if (!potions.isEmpty()) {
+      kits.add(new KitPotion(potions));
     }
-    if (element.getAttributeValue("color") != null) {
-      LeatherArmorMeta leatherMeta = (LeatherArmorMeta) itemStack.getItemMeta();
-      leatherMeta.setColor(Colors.convertHexToRgb(element.getAttributeValue("color")));
-      itemStack.setItemMeta(leatherMeta);
+    Set<AttributeModifier> attributes = Sets.newHashSet();
+    attributes.addAll(element.getChildren("attribute").stream().map(attr -> new AttributeModifier(
+        UUID.randomUUID(), attr.getText(),
+        Double.parseDouble(attr.getAttributeValue("amount", "0.0")),
+        DocumentItems.getOperation(attr.getAttributeValue("operation", "add")))).collect(Collectors.toList()));
+    if (!attributes.isEmpty()) {
+      kits.add(new KitAttribute(attributes));
     }
-
-    return itemStack; //TODO: Item mods
+    if (element.getChildText("walk-speed") != null) {
+      kits.add(new KitWalkSpeed(Float.parseFloat(element.getChildText("walk-speed")) / 5));
+    }
+    if (element.getChildText("knockback-reduction") != null) {
+      kits.add(new KitKnockback(Float.parseFloat(element.getChildText("knockback-reduction"))));
+    }
+    for (Element jump : element.getChildren("double-jump")) {
+      boolean enabled = Numbers.parseBoolean(jump.getAttributeValue("enabled"), true);
+      int power = Numbers.parseInteger(jump.getAttributeValue("power"), 3);
+      double rechargeTime = Strings.timeStringToExactSeconds(jump.getAttributeValue("recharge-time", "2.5s"));
+      boolean rechargeBeforeLand = Numbers.parseBoolean(jump.getAttributeValue("recharge-before-landing"), false);
+      kits.add(new KitDoubleJump(new KitDoubleJump.DoubleJumpData(enabled, power, rechargeTime, rechargeBeforeLand)));
+    }
+    for (Element jump : element.getChildren("fly")) {
+      boolean canFly = Numbers.parseBoolean(jump.getAttributeValue("can-fly"), true);
+      boolean flying = Numbers.parseBoolean(jump.getAttributeValue("flying"), false);
+      float flySpeed = Float.parseFloat(jump.getAttributeValue("fly-speed", "1")) / 10F;
+      kits.add(new KitFly(canFly, flying, flySpeed));
+    }
+    Filter filter = Cardinal.getModule(FilterModule.class)
+        .getFilter(match, element.getAttributeValue("filter", "always"));
+    String parent = element.getAttributeValue("parents", "");
+    List<String> parents = Lists.newArrayList();
+    for (String parentPart : parent.split(",")) {
+      parents.add(parentPart.trim());
+    }
+    boolean force = Numbers.parseBoolean(element.getAttributeValue("force"), false);
+    boolean potionParticles = Numbers.parseBoolean(element.getAttributeValue("potion-particles"), false);
+    boolean discardPotionBottles = Numbers.parseBoolean(element.getAttributeValue("discard-potion-bottles"), true);
+    boolean resetPearls = Numbers.parseBoolean(element.getAttributeValue("reset-ender-pearls"), false);
+    return new AbstractMap.SimpleEntry<>(name,
+        new KitCluster(match, filter, force, potionParticles, discardPotionBottles, resetPearls, parents, kits));
   }
 
-  private static ItemStack applyMeta(ItemStack itemStack, Element element) {
-    for (Element enchant : element.getChildren("enchantment")) {
-      String ench = enchant.getText();
-      Enchantment enchantment = Enchantment.getByName(Strings.getTechnicalName(ench));
-      int lvl = Numbers.parseInteger(enchant.getAttributeValue("level"), 1);
-      if (enchantment == null) {
-        //TODO: NMS name check
-      } else {
-        itemStack.addUnsafeEnchantment(enchantment, lvl);
-      }
-    }
-    ItemMeta meta = itemStack.getItemMeta();
-    for (Element effect : element.getChildren("effect")) {
-      PotionEffect potionEffect = getPotion(effect);
-      if (!((PotionMeta) meta).getCustomEffects().contains(potionEffect)) {
-        ((PotionMeta) meta).addCustomEffect(potionEffect, true);
-      }
-    }
-    for (Element attribute : element.getChildren("attribute")) {
-      ItemAttributeModifier itemAttribute = getAttribute(attribute);
-      if (!meta.getModifiedAttributes().contains(attribute.getText())) {
-        meta.addAttributeModifier(attribute.getText(), itemAttribute);
-      }
-    }
-    /* TODO: can-destroy & can-place-on, and all attributes
-     * @link https://docs.oc.tc/modules/item_mods#itemmeta
-     */
-    itemStack.setItemMeta(meta);
-    return itemStack;
-  }
-
-  private static List<PotionEffect> parseEffects(String effects) {
-    List<PotionEffect> effectList = Lists.newArrayList();
-    for (String effect : effects.split(";")) {
-      String[] split = effect.split(":");
-      PotionEffectType type = PotionEffectType.getByName(Strings.getTechnicalName(split[0]));
-      //TODO: NMS Inclusion
-      effectList.add(new PotionEffect(type, Numbers.parseInteger(split[1]), Numbers.parseInteger(split[2])));
-    }
-    return effectList;
-  }
-
-  private static List<ItemAttributeModifier> parseAttributes(String attributes) {
-    List<ItemAttributeModifier> list = Lists.newArrayList();
-    for (String attribute : attributes.split(";")) {
-      String[] attr = attribute.split(":");
-      list.add(new ItemAttributeModifier(null,
-          new AttributeModifier(UUID.randomUUID(), attr[0], Numbers.parseDouble(attr[2]), getOperation(attr[1]))));
-    }
-    return list;
-  }
-
-  private static PotionEffect getPotion(Element potion) {
-    PotionEffectType type = PotionEffectType.getByName(Strings.getTechnicalName(potion.getText()));
-    if (type == null) {
-      //TODO: NMS potion types
-    }
-    int duration = Numbers.parseInteger(potion.getAttributeValue("duration")) == Integer.MAX_VALUE
-        ? Numbers.parseInteger(potion.getAttributeValue("duration"))
-        : Numbers.parseInteger(potion.getAttributeValue("duration")) * 20;
-    int amplifier = 0;
-    boolean ambient = Numbers.parseBoolean(potion.getAttributeValue("ambient"));
-    if (potion.getAttributeValue("amplifier") != null) {
-      amplifier = Numbers.parseInteger(potion.getAttributeValue("amplifier")) - 1;
-    }
-
-    return new PotionEffect(type, duration, amplifier, ambient);
-  }
-
-  private static ItemAttributeModifier getAttribute(Element attribute) {
-    return new ItemAttributeModifier(getEquipmentSlot(attribute.getAttributeValue("slot", "")),
-        new AttributeModifier(UUID.randomUUID(), attribute.getText(),
-            Double.parseDouble(attribute.getAttributeValue("amount", "0.0")),
-            getOperation(attribute.getAttributeValue("operation", "add"))));
-  }
-
-  private static AttributeModifier.Operation getOperation(String operation) {
-    if (Numbers.isNumber(operation)) {
-      return AttributeModifier.Operation.fromOpcode(Integer.parseInt(operation));
-    } else {
-      switch (operation.toLowerCase()) {
-        case ("base"):
-          return AttributeModifier.Operation.ADD_SCALAR;
-        case ("multiply"):
-          return AttributeModifier.Operation.MULTIPLY_SCALAR_1;
-        case ("add"):
-        default:
-          return AttributeModifier.Operation.ADD_NUMBER;
-      }
-    }
-  }
-
-  private static EquipmentSlot getEquipmentSlot(String slotName) {
-    if (!slotName.startsWith("slot.")) {
-      slotName = "slot." + slotName;
-    }
-    EquipmentSlot equipmentSlot = null;
-    String[] path = slotName.split("\\.");
-    if (path.length == 3) {
-      if (path[1].equalsIgnoreCase("armor")) {
-        equipmentSlot = EquipmentSlot.valueOf(Strings.getTechnicalName(path[2]));
-      } else if (path[1].equalsIgnoreCase("weapon")) {
-        if (path[2].equalsIgnoreCase("mainhand")) {
-          equipmentSlot = EquipmentSlot.HAND;
-        }
-        if (path[2].equalsIgnoreCase("offhand")) {
-          equipmentSlot = EquipmentSlot.OFF_HAND;
-        }
-      }
-    }
-    return equipmentSlot;
-  }
 }

--- a/src/main/java/in/twizmwaz/cardinal/module/kit/type/KitCluster.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/kit/type/KitCluster.java
@@ -46,7 +46,7 @@ public class KitCluster implements KitRemovable {
 
   private final Match match;
 
-  private final Filter<Player> filter;
+  private final Filter filter;
   private final boolean force;
   private final boolean potionParticles;
   private final boolean discardPotionBottles;
@@ -60,7 +60,7 @@ public class KitCluster implements KitRemovable {
   @Override
   public void apply(Player player, boolean force) {
     evaluateParents();
-    if (filter != null && filter.evaluate(player)) {
+    if (filter.evaluate(player).toBoolean()) {
       for (Kit kit : parents) {
         kit.apply(player, force || this.force);
       }

--- a/src/main/java/in/twizmwaz/cardinal/module/objective/Objective.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/objective/Objective.java
@@ -29,8 +29,11 @@ import com.google.common.collect.Lists;
 import ee.ellytr.chat.component.formattable.UnlocalizedComponent;
 import in.twizmwaz.cardinal.Cardinal;
 import in.twizmwaz.cardinal.match.Match;
+import in.twizmwaz.cardinal.module.objective.core.Core;
 import in.twizmwaz.cardinal.module.objective.core.CoreModule;
+import in.twizmwaz.cardinal.module.objective.destroyable.Destroyable;
 import in.twizmwaz.cardinal.module.objective.destroyable.DestroyableModule;
+import in.twizmwaz.cardinal.module.objective.wool.Wool;
 import in.twizmwaz.cardinal.module.objective.wool.WoolModule;
 import lombok.Data;
 import lombok.NonNull;
@@ -80,6 +83,30 @@ public abstract class Objective {
       }
     }
     return specificObjective;
+  }
+
+  /**
+   * Gets the objective with the id on a specific match;
+   *
+   * @return The objective. Null if no objective is found with that id.
+   */
+  public static Objective getObjectiveById(@NonNull Match match, @NonNull String id) {
+    for (Core core : Cardinal.getModule(CoreModule.class).getCores(match)) {
+      if (core.getId().equalsIgnoreCase(id)) {
+        return core;
+      }
+    }
+    for (Destroyable monument : Cardinal.getModule(DestroyableModule.class).getDestroyables(match)) {
+      if (monument.getId().equalsIgnoreCase(id)) {
+        return monument;
+      }
+    }
+    for (Wool wool : Cardinal.getModule(WoolModule.class).getWools(match)) {
+      if (wool.getId().equalsIgnoreCase(id)) {
+        return wool;
+      }
+    }
+    return null;
   }
 
 }

--- a/src/main/java/in/twizmwaz/cardinal/module/objective/wool/WoolModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/objective/wool/WoolModule.java
@@ -327,7 +327,7 @@ public class WoolModule extends AbstractModule {
     for (Wool wool : wools.get(Cardinal.getMatch(event.getWorld()))) {
       Player player = event.getPlayer();
       Block block = event.getBlock();
-      if (wool.getMonument().evaluate(block.getLocation().toVector()) && !wool.isComplete()) {
+      if (wool.getMonument().evaluate(block.getLocation().toVector()).toBoolean() && !wool.isComplete()) {
         if (block.getType().equals(Material.WOOL)) {
           if (((org.bukkit.material.Wool) block.getState().getMaterialData()).getColor().equals(wool.getColor())) {
             wool.setComplete(true);
@@ -378,7 +378,7 @@ public class WoolModule extends AbstractModule {
   @EventHandler(ignoreCancelled = true)
   public void onBlockBreak(BlockBreakEvent event) {
     for (Wool wool : wools.get(Cardinal.getMatch(event.getWorld()))) {
-      if (wool.getMonument().evaluate(event.getBlock().getLocation().toVector())) {
+      if (wool.getMonument().evaluate(event.getBlock().getLocation().toVector()).toBoolean()) {
         event.setCancelled(true);
         break;
       }
@@ -393,7 +393,7 @@ public class WoolModule extends AbstractModule {
   @EventHandler(ignoreCancelled = true)
   public void onBlockForm(BlockFormEvent event) {
     for (Wool wool : wools.get(Cardinal.getMatch(event.getWorld()))) {
-      if (wool.getMonument().evaluate(event.getBlock().getLocation().toVector())) {
+      if (wool.getMonument().evaluate(event.getBlock().getLocation().toVector()).toBoolean()) {
         event.setCancelled(true);
         break;
       }
@@ -408,7 +408,7 @@ public class WoolModule extends AbstractModule {
   @EventHandler(ignoreCancelled = true)
   public void onBlockSpread(BlockSpreadEvent event) {
     for (Wool wool : wools.get(Cardinal.getMatch(event.getWorld()))) {
-      if (wool.getMonument().evaluate(event.getBlock().getLocation().toVector())) {
+      if (wool.getMonument().evaluate(event.getBlock().getLocation().toVector()).toBoolean()) {
         event.setCancelled(true);
         break;
       }
@@ -423,7 +423,7 @@ public class WoolModule extends AbstractModule {
   @EventHandler(ignoreCancelled = true)
   public void onEntityChangeBlock(EntityChangeBlockEvent event) {
     for (Wool wool : wools.get(Cardinal.getMatch(event.getWorld()))) {
-      if (wool.getMonument().evaluate(event.getBlock().getLocation().toVector())) {
+      if (wool.getMonument().evaluate(event.getBlock().getLocation().toVector()).toBoolean()) {
         event.setCancelled(true);
         break;
       }
@@ -441,15 +441,15 @@ public class WoolModule extends AbstractModule {
       Region monument = wool.getMonument();
       Block piston = event.getBlock();
       BlockFace direction = event.getDirection();
-      if (monument.evaluate(piston.getRelative(direction).getLocation().toVector())) {
+      if (monument.evaluate(piston.getRelative(direction).getLocation().toVector()).toBoolean()) {
         //Cancels the event if the piston's arm extends into the monument
         event.setCancelled(true);
         break;
       } else {
         //Cancels the event if any of the pushed blocks extend into the monument
         for (Block block : event.getBlocks()) {
-          if (monument.evaluate(block.getLocation().toVector())
-              || monument.evaluate(block.getRelative(direction).getLocation().toVector())) {
+          if (monument.evaluate(block.getLocation().toVector()).toBoolean()
+              || monument.evaluate(block.getRelative(direction).getLocation().toVector()).toBoolean()) {
             event.setCancelled(true);
             break;
           }
@@ -470,8 +470,8 @@ public class WoolModule extends AbstractModule {
       Region monument = wool.getMonument();
       BlockFace direction = event.getDirection();
       for (Block block : event.getBlocks()) {
-        if (monument.evaluate(block.getLocation().toVector())
-            || monument.evaluate(block.getRelative(direction).getLocation().toVector())) {
+        if (monument.evaluate(block.getLocation().toVector()).toBoolean()
+            || monument.evaluate(block.getRelative(direction).getLocation().toVector()).toBoolean()) {
           event.setCancelled(true);
           break;
         }

--- a/src/main/java/in/twizmwaz/cardinal/module/region/AbstractRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/AbstractRegion.java
@@ -25,11 +25,14 @@
 
 package in.twizmwaz.cardinal.module.region;
 
+import in.twizmwaz.cardinal.module.filter.FilterState;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.util.Vector;
 
 import java.util.Collection;
 import java.util.Random;
@@ -44,5 +47,27 @@ public abstract class AbstractRegion implements Region {
   private Collection<Block> blocks;
 
   private Random random = new Random();
+
+  @Override
+  public FilterState evaluate(Object... objects) {
+    for (Object obj : objects) {
+      FilterState response = FilterState.fromBoolean(this.evaluate(obj));
+      if (!response.equals(FilterState.ABSTAIN)) {
+        return response;
+      }
+    }
+    return FilterState.ABSTAIN;
+  }
+
+  private Boolean evaluate(Object obj) {
+    if (obj instanceof Vector) {
+      return this.contains((Vector) obj);
+    } else if (obj instanceof Block) {
+      return evaluate(((Block) obj).getLocation());
+    } else if (obj instanceof Entity) {
+      return evaluate(((Entity) obj).getLocation());
+    }
+    return null;
+  }
 
 }

--- a/src/main/java/in/twizmwaz/cardinal/module/region/Region.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/Region.java
@@ -31,7 +31,9 @@ import org.bukkit.util.Vector;
 
 import java.util.Collection;
 
-public interface Region extends Filter<Vector> {
+public interface Region extends Filter {
+
+  boolean contains(Vector vector);
 
   boolean isRandomizable();
 

--- a/src/main/java/in/twizmwaz/cardinal/module/region/type/AboveRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/type/AboveRegion.java
@@ -50,7 +50,7 @@ public class AboveRegion extends AbstractRegion {
   }
 
   @Override
-  public boolean evaluate(Vector vector) {
+  public boolean contains(Vector vector) {
     return vector.isGreater(min);
   }
 

--- a/src/main/java/in/twizmwaz/cardinal/module/region/type/BelowRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/type/BelowRegion.java
@@ -50,7 +50,7 @@ public class BelowRegion extends AbstractRegion {
   }
 
   @Override
-  public boolean evaluate(Vector vector) {
+  public boolean contains(Vector vector) {
     return max.isGreater(vector);
   }
 

--- a/src/main/java/in/twizmwaz/cardinal/module/region/type/BlockRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/type/BlockRegion.java
@@ -51,7 +51,7 @@ public class BlockRegion extends AbstractRegion {
   }
 
   @Override
-  public boolean evaluate(Vector vector) {
+  public boolean contains(Vector vector) {
     return vector.getBlockX() == getVector().getBlockX()
         && vector.getBlockY() == getVector().getBlockY()
         && vector.getBlockZ() == getVector().getBlockZ();

--- a/src/main/java/in/twizmwaz/cardinal/module/region/type/CircleRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/type/CircleRegion.java
@@ -59,7 +59,7 @@ public class CircleRegion extends AbstractRegion {
   }
 
   @Override
-  public boolean evaluate(Vector vector) {
+  public boolean contains(Vector vector) {
     return Math.hypot(Math.abs(vector.getX() - center.getX()), Math.abs(vector.getZ() - center.getZ())) <= radius;
   }
 

--- a/src/main/java/in/twizmwaz/cardinal/module/region/type/CuboidRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/type/CuboidRegion.java
@@ -56,7 +56,7 @@ public class CuboidRegion extends AbstractRegion {
   }
 
   @Override
-  public boolean evaluate(Vector vector) {
+  public boolean contains(Vector vector) {
     return cuboid.contains(vector);
   }
 

--- a/src/main/java/in/twizmwaz/cardinal/module/region/type/CylinderRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/type/CylinderRegion.java
@@ -83,7 +83,7 @@ public class CylinderRegion extends AbstractRegion {
       return super.getBlocks();
     }
     Collection<Block> blocks = getBounds().getBlocks().stream().filter(
-        block -> evaluate(block.getLocation().toVector().plus(0.5, 0.5, 0.5))).collect(Collectors.toSet());
+        block -> contains(block.getLocation().toVector().plus(0.5, 0.5, 0.5))).collect(Collectors.toSet());
     setBlocks(ImmutableSet.copyOf(blocks));
     return super.getBlocks();
   }
@@ -101,7 +101,7 @@ public class CylinderRegion extends AbstractRegion {
   }
 
   @Override
-  public boolean evaluate(Vector evaluating) {
+  public boolean contains(Vector evaluating) {
     return Math.hypot(Math.abs(evaluating.getX() - base.getX()), Math.abs(evaluating.getZ() - base.getZ())) <= radius
         && base.getY() <= evaluating.getY() && evaluating.getY() <= base.getY() + height;
   }

--- a/src/main/java/in/twizmwaz/cardinal/module/region/type/EmptyRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/type/EmptyRegion.java
@@ -40,7 +40,7 @@ public class EmptyRegion extends AbstractRegion {
   }
 
   @Override
-  public boolean evaluate(Vector vector) {
+  public boolean contains(Vector vector) {
     return false;
   }
 

--- a/src/main/java/in/twizmwaz/cardinal/module/region/type/EverywhereRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/type/EverywhereRegion.java
@@ -40,7 +40,7 @@ public class EverywhereRegion extends AbstractRegion {
   }
 
   @Override
-  public boolean evaluate(Vector vector) {
+  public boolean contains(Vector vector) {
     return true;
   }
 

--- a/src/main/java/in/twizmwaz/cardinal/module/region/type/HalfRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/type/HalfRegion.java
@@ -58,7 +58,7 @@ public class HalfRegion extends AbstractRegion {
   }
 
   @Override
-  public boolean evaluate(Vector vector) {
+  public boolean contains(Vector vector) {
     return this.normal.angle(vector.minus(origin)) <= HALF_PI;
   }
 

--- a/src/main/java/in/twizmwaz/cardinal/module/region/type/NowhereRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/type/NowhereRegion.java
@@ -40,7 +40,7 @@ public class NowhereRegion extends AbstractRegion {
   }
 
   @Override
-  public boolean evaluate(Vector vector) {
+  public boolean contains(Vector vector) {
     return false;
   }
 

--- a/src/main/java/in/twizmwaz/cardinal/module/region/type/PointRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/type/PointRegion.java
@@ -57,7 +57,7 @@ public class PointRegion extends AbstractRegion {
   }
 
   @Override
-  public boolean evaluate(Vector evaluating) {
+  public boolean contains(Vector evaluating) {
     return evaluating != null && evaluating.equals(location.toVector());
   }
 }

--- a/src/main/java/in/twizmwaz/cardinal/module/region/type/SphereRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/type/SphereRegion.java
@@ -79,7 +79,7 @@ public class SphereRegion extends AbstractRegion {
       return super.getBlocks();
     }
     Collection<Block> blocks = getBounds().getBlocks().stream().filter(
-        block -> evaluate(block.getLocation().toVector().plus(0.5, 0.5, 0.5))).collect(Collectors.toSet());
+        block -> contains(block.getLocation().toVector().plus(0.5, 0.5, 0.5))).collect(Collectors.toSet());
     setBlocks(ImmutableSet.copyOf(blocks));
     return super.getBlocks();
   }
@@ -90,7 +90,7 @@ public class SphereRegion extends AbstractRegion {
   }
 
   @Override
-  public boolean evaluate(Vector evaluating) {
+  public boolean contains(Vector evaluating) {
     return evaluating.isInSphere(origin, radius);
   }
 

--- a/src/main/java/in/twizmwaz/cardinal/module/region/type/modifications/ComplementRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/type/modifications/ComplementRegion.java
@@ -76,7 +76,7 @@ public class ComplementRegion extends AbstractRegion {
       throw new UnsupportedOperationException("Cannot get blocks in unbounded region");
     }
     Collection<Block> blocks = getBounds().getBlocks().stream().filter(
-        block -> evaluate(block.getLocation().toVector().plus(0.5, 0.5, 0.5))).collect(Collectors.toSet());
+        block -> contains(block.getLocation().toVector().plus(0.5, 0.5, 0.5))).collect(Collectors.toSet());
     setBlocks(ImmutableSet.copyOf(blocks));
     return super.getBlocks();
   }
@@ -87,12 +87,12 @@ public class ComplementRegion extends AbstractRegion {
   }
 
   @Override
-  public boolean evaluate(Vector evaluating) {
-    if (!region.evaluate(evaluating)) {
+  public boolean contains(Vector evaluating) {
+    if (!region.contains(evaluating)) {
       return false;
     }
     for (Region complement : complements) {
-      if (complement.evaluate(evaluating)) {
+      if (complement.contains(evaluating)) {
         return false;
       }
     }

--- a/src/main/java/in/twizmwaz/cardinal/module/region/type/modifications/IntersectRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/type/modifications/IntersectRegion.java
@@ -80,7 +80,7 @@ public class IntersectRegion extends AbstractRegion {
       return super.getBlocks();
     }
     Collection<Block> blocks = getBounds().getBlocks().stream().filter(
-        block -> evaluate(block.getLocation().toVector().plus(0.5, 0.5, 0.5))).collect(Collectors.toSet());
+        block -> contains(block.getLocation().toVector().plus(0.5, 0.5, 0.5))).collect(Collectors.toSet());
     setBlocks(ImmutableSet.copyOf(blocks));
     return super.getBlocks();
   }
@@ -91,9 +91,9 @@ public class IntersectRegion extends AbstractRegion {
   }
 
   @Override
-  public boolean evaluate(Vector evaluating) {
+  public boolean contains(Vector evaluating) {
     for (Region region : regions) {
-      if (!region.evaluate(evaluating)) {
+      if (!region.contains(evaluating)) {
         return false;
       }
     }

--- a/src/main/java/in/twizmwaz/cardinal/module/region/type/modifications/MirroredRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/type/modifications/MirroredRegion.java
@@ -60,8 +60,8 @@ public class MirroredRegion extends AbstractRegion {
   }
 
   @Override
-  public boolean evaluate(Vector vector) {
-    return region.evaluate(Geometry.getMirrored(vector, origin, normal));
+  public boolean contains(Vector vector) {
+    return region.contains(Geometry.getMirrored(vector, origin, normal));
   }
 
   @Override
@@ -83,7 +83,7 @@ public class MirroredRegion extends AbstractRegion {
       return super.getBlocks();
     }
     Collection<Block> blocks = getBounds().getBlocks().stream().filter(
-        block -> evaluate(block.getLocation().toVector().add(0.5, 0.5, 0.5))).collect(Collectors.toSet());
+        block -> contains(block.getLocation().toVector().add(0.5, 0.5, 0.5))).collect(Collectors.toSet());
     setBlocks(blocks);
     return super.getBlocks();
   }

--- a/src/main/java/in/twizmwaz/cardinal/module/region/type/modifications/NegativeRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/type/modifications/NegativeRegion.java
@@ -70,7 +70,7 @@ public class NegativeRegion extends AbstractRegion {
   }
 
   @Override
-  public boolean evaluate(Vector evaluating) {
-    return !region.evaluate(evaluating);
+  public boolean contains(Vector evaluating) {
+    return !region.contains(evaluating);
   }
 }

--- a/src/main/java/in/twizmwaz/cardinal/module/region/type/modifications/PointProviderRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/type/modifications/PointProviderRegion.java
@@ -71,7 +71,7 @@ public class PointProviderRegion extends AbstractRegion {
   }
 
   @Override
-  public boolean evaluate(Vector evaluating) {
+  public boolean contains(Vector evaluating) {
     throw new UnsupportedOperationException("Cannot determine absolute location of PointProvider");
   }
 }

--- a/src/main/java/in/twizmwaz/cardinal/module/region/type/modifications/TranslatedRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/type/modifications/TranslatedRegion.java
@@ -56,8 +56,8 @@ public class TranslatedRegion extends AbstractRegion {
   }
 
   @Override
-  public boolean evaluate(Vector vector) {
-    return region.evaluate(vector.minus(offset));
+  public boolean contains(Vector vector) {
+    return region.contains(vector.minus(offset));
   }
 
   @Override
@@ -79,7 +79,7 @@ public class TranslatedRegion extends AbstractRegion {
       return super.getBlocks();
     }
     Collection<Block> blocks = getBounds().getBlocks().stream().filter(
-        block -> evaluate(block.getLocation().toVector().plus(0.5, 0.5, 0.5))).collect(Collectors.toSet());
+        block -> contains(block.getLocation().toVector().plus(0.5, 0.5, 0.5))).collect(Collectors.toSet());
     setBlocks(blocks);
     return super.getBlocks();
   }

--- a/src/main/java/in/twizmwaz/cardinal/module/region/type/modifications/UnionRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/region/type/modifications/UnionRegion.java
@@ -95,9 +95,9 @@ public class UnionRegion extends AbstractRegion {
   }
 
   @Override
-  public boolean evaluate(Vector evaluating) {
+  public boolean contains(Vector evaluating) {
     for (Region region : regions) {
-      if (region.evaluate(evaluating)) {
+      if (region.contains(evaluating)) {
         return true;
       }
     }

--- a/src/main/java/in/twizmwaz/cardinal/util/document/DocumentItems.java
+++ b/src/main/java/in/twizmwaz/cardinal/util/document/DocumentItems.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2016, Kevin Phoenix
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package in.twizmwaz.cardinal.util.document;
+
+import com.google.common.collect.Lists;
+import in.twizmwaz.cardinal.module.kit.type.KitItem;
+import in.twizmwaz.cardinal.util.Colors;
+import in.twizmwaz.cardinal.util.Numbers;
+import in.twizmwaz.cardinal.util.Strings;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.attribute.ItemAttributeModifier;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BookMeta;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
+import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.potion.Potion;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.jdom2.Element;
+
+import java.util.List;
+import java.util.UUID;
+
+public class DocumentItems {
+
+  public static KitItem.Item getKitItem(Element element) {
+    ItemStack itemStack = getItem(element);
+    int slot = -1;
+    String slotString = element.getAttributeValue("slot", "-1");
+    if (Numbers.isNumber(slotString)) {
+      slot = Integer.parseInt(slotString);
+    } else {
+      if (!slotString.startsWith("slot.")) {
+        slotString = "slot." + slotString;
+        //TODO: get an int from the slot WITHOUT unnecessary NMS.
+      }
+    }
+    return new KitItem.Item(itemStack, slot);
+  }
+
+  public static ItemStack getItem(Element element) {
+    int amount = Numbers.parseInteger(element.getAttributeValue("amount", "1"));
+    short damage = element.getAttributeValue("damage") != null
+        ? Numbers.parseShort(element.getAttributeValue("damage"))
+        : element.getText().split(":").length > 1
+        ? Numbers.parseShort(element.getText().split(":")[1], (short) 0)
+        : 0;
+    ItemStack itemStack = new ItemStack(Material.AIR);
+    if (element.getAttribute("material") != null) {
+      itemStack = new ItemStack(Material.matchMaterial(element.getAttributeValue("material")), amount, damage);
+    } else if (!element.getTextTrim().equals("")) {
+      itemStack = new ItemStack(Material.matchMaterial(element.getText().split(":")[0]), amount, damage);
+    }
+    if (itemStack.getType() == Material.POTION) {
+      itemStack = Potion.fromDamage(damage).toItemStack(amount);
+    }
+    if (element.getName().equalsIgnoreCase("book")) {
+      itemStack = new ItemStack(Material.BOOK, amount, damage);
+    }
+    if (element.getAttributeValue("enchantment") != null) {
+      for (String raw : element.getAttributeValue("enchantment").split(";")) {
+        String[] enchant = raw.split(":");
+        int lvl = enchant.length > 1 ? Numbers.parseInteger(enchant[1]) : 1;
+        Enchantment enchantment = Enchantment.getByName(Strings.getTechnicalName(enchant[0]));
+        if (enchantment == null) {
+          //TODO: NMS enchantment names
+        } else {
+          itemStack.addUnsafeEnchantment(Enchantment.getByName(Strings.getTechnicalName(enchant[0])), lvl);
+        }
+      }
+    }
+    ItemMeta meta = itemStack.getItemMeta();
+    if (Numbers.parseBoolean(element.getAttributeValue("unbreakable"))) {
+      meta.setUnbreakable(true);
+    }
+    if (element.getAttributeValue("name") != null) {
+      meta.setDisplayName(ChatColor.translateAlternateColorCodes('`', element.getAttributeValue("name")));
+    }
+    if (element.getAttributeValue("lore") != null) {
+      List<String> lore = Lists.newArrayList();
+      for (String raw : element.getAttributeValue("lore").split("\\|")) {
+        String colored = ChatColor.translateAlternateColorCodes('`', raw);
+        lore.add(colored);
+      }
+      meta.setLore(lore);
+    }
+    if (element.getAttributeValue("potions") != null) {
+      for (PotionEffect effect : parseEffects(element.getAttributeValue("potions"))) {
+        ((PotionMeta) meta).addCustomEffect(effect, true);
+      }
+    }
+    if (element.getAttributeValue("attributes") != null) {
+      for (ItemAttributeModifier attribute : parseAttributes((element.getAttributeValue("attributes")))) {
+        meta.addAttributeModifier(attribute.getModifier().getName(), attribute);
+      }
+    }
+    for (Element attribute : element.getChildren("attribute")) {
+      meta.addAttributeModifier(attribute.getText(), getAttribute(attribute));
+    }
+    itemStack.setItemMeta(meta);
+    if (element.getName().equalsIgnoreCase("book")) {
+      BookMeta bookMeta = (BookMeta) itemStack.getItemMeta();
+      bookMeta.setTitle(ChatColor.translateAlternateColorCodes('`', element.getChildText("author")));
+      bookMeta.setAuthor(ChatColor.translateAlternateColorCodes('`', element.getChildText("author")));
+      List<String> pages = Lists.newArrayList();
+      for (Element page : element.getChild("pages").getChildren("page")) {
+        pages.add(ChatColor.translateAlternateColorCodes('`', page.getText()).replace("\t", ""));
+      }
+      bookMeta.setPages(pages);
+      itemStack.setItemMeta(bookMeta);
+    }
+    if (element.getAttributeValue("color") != null) {
+      LeatherArmorMeta leatherMeta = (LeatherArmorMeta) itemStack.getItemMeta();
+      leatherMeta.setColor(Colors.convertHexToRgb(element.getAttributeValue("color")));
+      itemStack.setItemMeta(leatherMeta);
+    }
+    
+    return applyMeta(itemStack, element); //TODO: Item mods
+  }
+
+  public static ItemStack applyMeta(ItemStack itemStack, Element element) {
+    for (Element enchant : element.getChildren("enchantment")) {
+      String ench = enchant.getText();
+      Enchantment enchantment = Enchantment.getByName(Strings.getTechnicalName(ench));
+      int lvl = Numbers.parseInteger(enchant.getAttributeValue("level"), 1);
+      if (enchantment == null) {
+        //TODO: NMS name check
+      } else {
+        itemStack.addUnsafeEnchantment(enchantment, lvl);
+      }
+    }
+    ItemMeta meta = itemStack.getItemMeta();
+    for (Element effect : element.getChildren("effect")) {
+      PotionEffect potionEffect = getPotion(effect);
+      if (!((PotionMeta) meta).getCustomEffects().contains(potionEffect)) {
+        ((PotionMeta) meta).addCustomEffect(potionEffect, true);
+      }
+    }
+    for (Element attribute : element.getChildren("attribute")) {
+      ItemAttributeModifier itemAttribute = getAttribute(attribute);
+      if (!meta.getModifiedAttributes().contains(attribute.getText())) {
+        meta.addAttributeModifier(attribute.getText(), itemAttribute);
+      }
+    }
+    /* TODO: can-destroy & can-place-on, and all attributes
+     * @link https://docs.oc.tc/modules/item_mods#itemmeta
+     */
+    itemStack.setItemMeta(meta);
+    return itemStack;
+  }
+
+
+  private static List<PotionEffect> parseEffects(String effects) {
+    List<PotionEffect> effectList = Lists.newArrayList();
+    for (String effect : effects.split(";")) {
+      String[] split = effect.split(":");
+      PotionEffectType type = PotionEffectType.getByName(Strings.getTechnicalName(split[0]));
+      //TODO: NMS Inclusion
+      effectList.add(new PotionEffect(type, Numbers.parseInteger(split[1]), Numbers.parseInteger(split[2])));
+    }
+    return effectList;
+  }
+
+
+  private static List<ItemAttributeModifier> parseAttributes(String attributes) {
+    List<ItemAttributeModifier> list = Lists.newArrayList();
+    for (String attribute : attributes.split(";")) {
+      String[] attr = attribute.split(":");
+      list.add(new ItemAttributeModifier(null,
+          new AttributeModifier(UUID.randomUUID(), attr[0], Numbers.parseDouble(attr[2]), getOperation(attr[1]))));
+    }
+    return list;
+  }
+
+  public static PotionEffect getPotion(Element potion) {
+    PotionEffectType type = PotionEffectType.getByName(Strings.getTechnicalName(potion.getText()));
+    if (type == null) {
+      //TODO: NMS potion types
+    }
+    int duration = Numbers.parseInteger(potion.getAttributeValue("duration")) == Integer.MAX_VALUE
+        ? Numbers.parseInteger(potion.getAttributeValue("duration"))
+        : Numbers.parseInteger(potion.getAttributeValue("duration")) * 20;
+    int amplifier = 0;
+    boolean ambient = Numbers.parseBoolean(potion.getAttributeValue("ambient"));
+    if (potion.getAttributeValue("amplifier") != null) {
+      amplifier = Numbers.parseInteger(potion.getAttributeValue("amplifier")) - 1;
+    }
+
+    return new PotionEffect(type, duration, amplifier, ambient);
+  }
+
+  private static ItemAttributeModifier getAttribute(Element attribute) {
+    return new ItemAttributeModifier(getEquipmentSlot(attribute.getAttributeValue("slot", "")),
+        new AttributeModifier(UUID.randomUUID(), attribute.getText(),
+            Double.parseDouble(attribute.getAttributeValue("amount", "0.0")),
+            getOperation(attribute.getAttributeValue("operation", "add"))));
+  }
+
+  public static AttributeModifier.Operation getOperation(String operation) {
+    if (Numbers.isNumber(operation)) {
+      return AttributeModifier.Operation.fromOpcode(Integer.parseInt(operation));
+    } else {
+      switch (operation.toLowerCase()) {
+        case ("base"):
+          return AttributeModifier.Operation.ADD_SCALAR;
+        case ("multiply"):
+          return AttributeModifier.Operation.MULTIPLY_SCALAR_1;
+        case ("add"):
+        default:
+          return AttributeModifier.Operation.ADD_NUMBER;
+      }
+    }
+  }
+
+  private static EquipmentSlot getEquipmentSlot(String slotName) {
+    if (!slotName.startsWith("slot.")) {
+      slotName = "slot." + slotName;
+    }
+    EquipmentSlot equipmentSlot = null;
+    String[] path = slotName.split("\\.");
+    if (path.length == 3) {
+      if (path[1].equalsIgnoreCase("armor")) {
+        equipmentSlot = EquipmentSlot.valueOf(Strings.getTechnicalName(path[2]));
+      } else if (path[1].equalsIgnoreCase("weapon")) {
+        if (path[2].equalsIgnoreCase("mainhand")) {
+          equipmentSlot = EquipmentSlot.HAND;
+        }
+        if (path[2].equalsIgnoreCase("offhand")) {
+          equipmentSlot = EquipmentSlot.OFF_HAND;
+        }
+      }
+    }
+    return equipmentSlot;
+  }
+
+}


### PR DESCRIPTION
Now you can extend `SingleObjectFilter` that will give object by object for the filter to evaluate, you can also extend an `AgnosticFilter` for filters that don't requiere an input, or you can extend `ObjectTypeFilter<T>` for filters that only filter a certain object, for example `SomethingFilter extends ObjectTypeFilter<Player>`  note: needs to implement a `getType Class<T>()` method, it should just be something like:
```
public Class<Player> getType() {
  return Player.class;
}
```

Added FilterState, with allow, deny and abstain, and methods to convert from/to boolean

Regions are filter extensions, now there is one evaluate method, inside abstract region, that extracts vector from various classes (atm entities or blocks) and passes it into the contains method for regions.

Added modification filters (not, all, one, etc).
Added RangeFilter, parsing should be:
```
<range min="2" max="3">
  <filter id="some-filter">
  <filter id="some-filter">
  <filter id="some-filter">
</range>
```
(all the sub filters can be any type of filter)
min defaults to 0, max defaults to infinite.
If all child filters abstain, it will abstain, else it will allow if the number of filters that allowed is in the range (min and max inclusive), else it will deny.

Added LayerFilter, parsing should be:
```<layer coordinate="X" layer="10"/>```
When you try to place a block, this filter would test if at "10, block Y, block Z" there is a block.
The best way too look at this filter is that void filter is just a layer filter with Y coordinate, and layer 0.

Added a way to reference regions directly inside filters:
```<region id="region-id"/>```
Region needs to be created inside the `<regions>` tag, and then referenced by a filter, because a region is already a filter, this will just search for the region itself, and add it to the list of filters, or let it act as a child filter for any super-filter (like range filters)

Added `MatchModuleLoadCompleteEvent` thrown right after calling `loadMatch()` on all modules, errors are printed after the event is thrown, instead of before, so modules can still add errors to the list on the event listener. ATM it's used by the FilterModule, that runs a `load()` method on Filters that implement the interface `LoadLateFilter` (needs a better name) atm only used by `ObjectiveFilter`, that will save the element on filter creation, and find/reference the objective on the event, after the objective module loads the objectives.
